### PR TITLE
Conceal original URL (to prevent blocking)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -20,7 +20,7 @@
     iframe.style.top = 0
     iframe.style.left = 0
     newwin.document.body.appendChild(iframe)
-    window.open('', '_self').close();
+    window.location = "about:blank";
   </script>
   <div class="container containerPadding">
     <h1>AboutBrowser loading...</h1>


### PR DESCRIPTION
could be braindead, wasn't working for me in firefox or chromium. it would set the title of the original tab, but wouldn't close/modify it. this just sets it to about:blank and rewrites it in history.